### PR TITLE
Removed post-install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "index.js",
     "src"
   ],
-  "preferGlobal": true,
-  "scripts": {
-    "postInstall": "npm install ./ --global"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/adrianmg/github-pewpew.git"


### PR DESCRIPTION
I accidentally left a custom post-install script that will force a global installation of the command. It was meant to be for development purposes, but it's not needed anymore. Sorry about that.